### PR TITLE
fix(scripts/prompt): utilize new FiveM feature

### DIFF
--- a/client/prompt.lua
+++ b/client/prompt.lua
@@ -2,8 +2,7 @@
 local promptIsOpen = false
 
 --[[
-table object:
-  interface PromptInfo {
+interface PromptInfo {
   placeholder: string;
   description: string;
   id: string;
@@ -26,8 +25,7 @@ local function startPrompt(promptTable)
 
   promptIsOpen = true
 
-  RegisterNuiCallbackType(cbStr)
-  local eventData = AddEventHandler('__cfx_nui:' .. cbStr, function(data, cb)
+  local eventData = RegisterNUICallback(cbStr, function(data, cb)
     p:resolve(data)
     promptIsOpen = false
     cb({})


### PR DESCRIPTION
New FiveM feature eliminates memory leak in ResourceUI container allowing for unregistering of NUI callback events properly.

This is pending the PR and merge of my fixed FiveM build [here](https://github.com/TasoOneAsia/fivem/tree/feat/delete-nuicallback)